### PR TITLE
Report as weekend when missing log on a weekend

### DIFF
--- a/lib/done_log.rb
+++ b/lib/done_log.rb
@@ -47,6 +47,13 @@ module Done
         end
 
         puts
+      elsif date.saturday? or date.sunday?
+        puts <<~LOG
+      #{Done::ANSIColors.colorize(date_string, @date_color)}
+
+      [Weekend]
+
+        LOG
       else
         puts <<~LOG
       #{Done::ANSIColors.colorize(date_string, @date_color)}


### PR DESCRIPTION
Make it easy to spot weekends when reporting logs.

If there is no log for a weekend date, show

```
[Weekend]
```